### PR TITLE
Enhance GrantsTable filtering and implement rolling grants support

### DIFF
--- a/lib/chatbot-api/functions/landing-page/nofo-status/index.mjs
+++ b/lib/chatbot-api/functions/landing-page/nofo-status/index.mjs
@@ -27,7 +27,7 @@ const VALID_GRANT_TYPES = ['federal', 'state', 'quasi', 'philanthropic'];
 /**
  * Update NOFO metadata in DynamoDB
  */
-async function updateDynamoDB(tableName, nofoName, status, isPinned, expirationDate, grantType, category, agency) {
+async function updateDynamoDB(tableName, nofoName, status, isPinned, expirationDate, grantType, category, agency, isRolling) {
   const dynamoClient = new DynamoDBClient();
   const now = new Date().toISOString();
 
@@ -83,6 +83,11 @@ async function updateDynamoDB(tableName, nofoName, status, isPinned, expirationD
         expressionAttributeValues[':agency'] = agency || null;
       }
 
+      if (isRolling !== undefined) {
+        updateExpression.push('is_rolling = :is_rolling');
+        expressionAttributeValues[':is_rolling'] = String(isRolling);
+      }
+
       updateExpression.push('#updated_at = :updated_at');
       expressionAttributeNames['#updated_at'] = 'updated_at';
       expressionAttributeValues[':updated_at'] = now;
@@ -112,6 +117,7 @@ async function updateDynamoDB(tableName, nofoName, status, isPinned, expirationD
         nofo_name: nofoName,
         status: status || 'active',
         isPinned: String(isPinned !== undefined ? isPinned : false),
+        is_rolling: String(isRolling !== undefined ? isRolling : false),
         expiration_date: expirationDate || null,
         grant_type: grantType || null,
         category: category,
@@ -145,7 +151,7 @@ export const handler = async (event) => {
   try {
     // Parse the request body to get the NOFO name and status
     const requestBody = JSON.parse(event.body);
-    const { nofoName, status, isPinned, expirationDate, grantType, category, agency } = requestBody;
+    const { nofoName, status, isPinned, expirationDate, grantType, category, agency, isRolling } = requestBody;
 
     // Validate input
     if (!nofoName) {
@@ -230,6 +236,11 @@ export const handler = async (event) => {
       summaryObject.agency = agency || null;
     }
 
+    // Update the rolling flag if provided
+    if (isRolling !== undefined) {
+      summaryObject.is_rolling = isRolling;
+    }
+
     // Ensure default values match existing code behavior
     if (!summaryObject.status) {
       summaryObject.status = 'active';
@@ -267,7 +278,8 @@ export const handler = async (event) => {
         summaryObject.application_deadline,
         summaryObject.grant_type,
         categoryToUse,
-        agencyToUse
+        agencyToUse,
+        isRolling
       );
 
       if (!dynamoResult.success) {

--- a/lib/chatbot-api/functions/landing-page/retrieve-nofos/index.mjs
+++ b/lib/chatbot-api/functions/landing-page/retrieve-nofos/index.mjs
@@ -69,6 +69,7 @@ async function fetchFromDynamoDB(tableName) {
         processing_status: nofo.processing_status || null,
         // Convert string 'true'/'false' from DynamoDB to boolean, matching S3 format
         isPinned: nofo.isPinned === 'true' || nofo.isPinned === true,
+        is_rolling: nofo.is_rolling === 'true' || nofo.is_rolling === true || false,
         expiration_date: nofo.expiration_date || null,
         grant_type: nofo.grant_type || null,
         agency: nofo.agency || null,

--- a/lib/user-interface/app/src/common/api-client/landing-page-clients.ts
+++ b/lib/user-interface/app/src/common/api-client/landing-page-clients.ts
@@ -201,7 +201,8 @@ export class LandingPageClient {
     expirationDate?: string | null,
     grantType?: "federal" | "state" | "quasi" | "philanthropic",
     category?: string,
-    agency?: string
+    agency?: string,
+    isRolling?: boolean
   ) {
     try {
       const token = await Utils.authenticate();
@@ -211,7 +212,7 @@ export class LandingPageClient {
           "Content-Type": "application/json",
           Authorization: token,
         },
-        body: JSON.stringify({ nofoName, status, isPinned, expirationDate, grantType, category, agency }),
+        body: JSON.stringify({ nofoName, status, isPinned, expirationDate, grantType, category, agency, isRolling }),
       });
 
       const data = await response.json();

--- a/lib/user-interface/app/src/common/types/document.ts
+++ b/lib/user-interface/app/src/common/types/document.ts
@@ -59,6 +59,7 @@ export interface RawNOFOData {
   status: string;
   processing_status?: string | null;
   isPinned?: boolean;
+  is_rolling?: boolean;
   expiration_date?: string | null;
   grant_type?: string | null;
   agency?: string | null;

--- a/lib/user-interface/app/src/common/types/nofo.ts
+++ b/lib/user-interface/app/src/common/types/nofo.ts
@@ -12,6 +12,7 @@ export interface NOFO {
   name: string;
   status: "active" | "archived";
   isPinned?: boolean;
+  isRolling?: boolean;
   expirationDate?: string | null;
   grantType?: GrantTypeId | null;
   agency?: string | null;

--- a/lib/user-interface/app/src/pages/dashboard/components/NOFOsTab.tsx
+++ b/lib/user-interface/app/src/pages/dashboard/components/NOFOsTab.tsx
@@ -49,6 +49,7 @@ const NOFOsTab = React.memo(function NOFOsTab({
   const [editedNofoStatus, setEditedNofoStatus] = useState<"active" | "archived">("active");
   const [editedNofoExpirationDate, setEditedNofoExpirationDate] = useState<string>("");
   const [editedNofoGrantType, setEditedNofoGrantType] = useState<GrantTypeId | "">("");
+  const [editedNofoIsRolling, setEditedNofoIsRolling] = useState<boolean>(false);
 
   const [summaryModalOpen, setSummaryModalOpen] = useState(false);
   const [summaryLoading, setSummaryLoading] = useState(false);
@@ -143,6 +144,7 @@ const NOFOsTab = React.memo(function NOFOsTab({
     setEditedNofoName(nofo.name);
     setEditedNofoStatus(nofo.status || "active");
     setEditedNofoGrantType(nofo.grantType || "");
+    setEditedNofoIsRolling(nofo.isRolling || false);
     if (nofo.expirationDate) {
       if (/^\d{4}-\d{2}-\d{2}$/.test(nofo.expirationDate)) {
         setEditedNofoExpirationDate(nofo.expirationDate);
@@ -181,10 +183,13 @@ const NOFOsTab = React.memo(function NOFOsTab({
       if (newGrantType !== (selectedNofo.grantType || null)) {
         await apiClient.landingPage.updateNOFOStatus(editedNofoName.trim(), undefined, undefined, undefined, newGrantType as GrantTypeId);
       }
+      if (editedNofoIsRolling !== (selectedNofo.isRolling || false)) {
+        await apiClient.landingPage.updateNOFOStatus(editedNofoName.trim(), undefined, undefined, undefined, undefined, undefined, undefined, editedNofoIsRolling);
+      }
       updateNofos((allNofos) =>
         allNofos.map((nofo) =>
           nofo.id === selectedNofo.id
-            ? { ...nofo, name: editedNofoName.trim(), status: editedNofoStatus, expirationDate: newExpirationDate, grantType: newGrantType as GrantTypeId | null }
+            ? { ...nofo, name: editedNofoName.trim(), status: editedNofoStatus, expirationDate: newExpirationDate, grantType: newGrantType as GrantTypeId | null, isRolling: editedNofoIsRolling }
             : nofo
         )
       );
@@ -194,6 +199,7 @@ const NOFOsTab = React.memo(function NOFOsTab({
       setEditedNofoName("");
       setEditedNofoExpirationDate("");
       setEditedNofoGrantType("");
+      setEditedNofoIsRolling(false);
     } catch {
       addNotification("error", "Failed to update grant. Please try again.");
     }
@@ -283,7 +289,8 @@ const NOFOsTab = React.memo(function NOFOsTab({
       editedNofoName !== selectedNofo.name ||
       editedNofoStatus !== selectedNofo.status ||
       editedNofoExpirationDate !== normalizedOldExp ||
-      editedNofoGrantType !== (selectedNofo.grantType || "")
+      editedNofoGrantType !== (selectedNofo.grantType || "") ||
+      editedNofoIsRolling !== (selectedNofo.isRolling || false)
     );
   };
 
@@ -293,7 +300,7 @@ const NOFOsTab = React.memo(function NOFOsTab({
         <div className="table-header">
           <div className="header-cell">Name</div>
           <div className="header-cell">Type</div>
-          <div className="header-cell">Expiry Date</div>
+          <div className="header-cell">Deadline</div>
           <div className="header-cell">Actions</div>
         </div>
         <div className="table-body">
@@ -333,10 +340,10 @@ const NOFOsTab = React.memo(function NOFOsTab({
                 )}
               </div>
               <div className="row-cell">
-                {nofo.expirationDate ? (
-                  <span className="expiry-date">{Utils.formatExpirationDate(nofo.expirationDate)}</span>
+                {nofo.isRolling || !nofo.expirationDate ? (
+                  <span className="expiry-date rolling">Rolling</span>
                 ) : (
-                  <span className="expiry-date no-date">N/A</span>
+                  <span className="expiry-date">{Utils.formatExpirationDate(nofo.expirationDate!)}</span>
                 )}
               </div>
               <div className="row-cell actions">
@@ -380,8 +387,19 @@ const NOFOsTab = React.memo(function NOFOsTab({
             <div className="field-note">Active grants are visible to users. Archived grants are hidden.</div>
           </div>
           <div className="form-group">
-            <label htmlFor="nofo-expiration-date">Expiry Date</label>
-            <input type="date" id="nofo-expiration-date" value={editedNofoExpirationDate} onChange={(e) => setEditedNofoExpirationDate(e.target.value)} className="form-input" />
+            <label style={{ display: "flex", alignItems: "center", gap: "8px", cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={editedNofoIsRolling}
+                onChange={(e) => setEditedNofoIsRolling(e.target.checked)}
+              />
+              Rolling grant (no fixed deadline)
+            </label>
+            <div className="field-note">Rolling grants show "Rolling" instead of a deadline date.</div>
+          </div>
+          <div className="form-group">
+            <label htmlFor="nofo-expiration-date">Deadline</label>
+            <input type="date" id="nofo-expiration-date" value={editedNofoExpirationDate} onChange={(e) => setEditedNofoExpirationDate(e.target.value)} className="form-input" disabled={editedNofoIsRolling} />
             <div className="field-note">Leave empty if no expiration date. Grants will be auto-archived after this date.</div>
           </div>
           <div className="form-group">

--- a/lib/user-interface/app/src/pages/landing-page/GrantsTable.tsx
+++ b/lib/user-interface/app/src/pages/landing-page/GrantsTable.tsx
@@ -289,7 +289,7 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
           <div className="landing-header-cell">Agency</div>
           <div className="landing-header-cell">Category</div>
           <div className="landing-header-cell">Type</div>
-          <div className="landing-header-cell">Expiry Date</div>
+          <div className="landing-header-cell">Deadline</div>
         </div>
 
         <div className="landing-table-body">
@@ -373,12 +373,12 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
                   )}
                 </div>
                 <div className="landing-row-cell" style={{ color: isArchived ? "#888" : undefined }}>
-                  {nofo.expirationDate ? (
+                  {nofo.isRolling || !nofo.expirationDate ? (
+                    <span className="landing-expiry-date rolling">Rolling</span>
+                  ) : (
                     <span className="landing-expiry-date">
                       {Utils.formatExpirationDate(nofo.expirationDate)}
                     </span>
-                  ) : (
-                    <span className="landing-expiry-date no-date">N/A</span>
                   )}
                 </div>
               </div>

--- a/lib/user-interface/app/src/pages/landing-page/GrantsTable.tsx
+++ b/lib/user-interface/app/src/pages/landing-page/GrantsTable.tsx
@@ -46,15 +46,33 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
   ).sort();
 
   const getCategoryCount = (category: string) => {
-    return nofos.filter((nofo) => nofo.category === category).length;
+    return nofos.filter((nofo) => {
+      return (
+        nofo.category === category &&
+        (statusFilter === "all" || nofo.status === statusFilter) &&
+        (grantTypeFilter === "all" || nofo.grantType === grantTypeFilter)
+      );
+    }).length;
   };
 
   const getStatusCount = (status: "active" | "archived") => {
-    return nofos.filter((nofo) => nofo.status === status).length;
+    return nofos.filter((nofo) => {
+      return (
+        nofo.status === status &&
+        (categoryFilter === "all" || nofo.category === categoryFilter) &&
+        (grantTypeFilter === "all" || nofo.grantType === grantTypeFilter)
+      );
+    }).length;
   };
 
   const getGrantTypeCount = (grantType: GrantTypeId) => {
-    return nofos.filter((nofo) => nofo.grantType === grantType).length;
+    return nofos.filter((nofo) => {
+      return (
+        nofo.grantType === grantType &&
+        (statusFilter === "all" || nofo.status === statusFilter) &&
+        (categoryFilter === "all" || nofo.category === categoryFilter)
+      );
+    }).length;
   };
 
   const scoreMap = useMemo(() => {
@@ -183,7 +201,10 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value as "all" | "active" | "archived")}
           >
-            <option value="all">All Grants ({nofos.length})</option>
+            <option value="all">All Grants ({nofos.filter((nofo) =>
+              (categoryFilter === "all" || nofo.category === categoryFilter) &&
+              (grantTypeFilter === "all" || nofo.grantType === grantTypeFilter)
+            ).length})</option>
             <option value="active">Active ({getStatusCount("active")})</option>
             <option value="archived">Archived ({getStatusCount("archived")})</option>
           </select>
@@ -197,7 +218,10 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
             value={categoryFilter}
             onChange={(e) => setCategoryFilter(e.target.value)}
           >
-            <option value="all">All Categories</option>
+            <option value="all">All Categories ({nofos.filter((nofo) =>
+              (statusFilter === "all" || nofo.status === statusFilter) &&
+              (grantTypeFilter === "all" || nofo.grantType === grantTypeFilter)
+            ).length})</option>
             {uniqueCategories.map((category) => {
               const count = getCategoryCount(category);
               return (
@@ -217,7 +241,10 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
             value={grantTypeFilter}
             onChange={(e) => setGrantTypeFilter(e.target.value as GrantTypeId | "all")}
           >
-            <option value="all">All Grant Types</option>
+            <option value="all">All Grant Types ({nofos.filter((nofo) =>
+              (statusFilter === "all" || nofo.status === statusFilter) &&
+              (categoryFilter === "all" || nofo.category === categoryFilter)
+            ).length})</option>
             {Object.keys(GRANT_TYPES).map((type) => {
               const grantType = type as GrantTypeId;
               const count = getGrantTypeCount(grantType);

--- a/lib/user-interface/app/src/pages/landing-page/LandingPage.tsx
+++ b/lib/user-interface/app/src/pages/landing-page/LandingPage.tsx
@@ -126,6 +126,7 @@ export default function Welcome() {
               name: nofo.name,
               status: nofo.status as "active" | "archived",
               isPinned: nofo.isPinned || false,
+              isRolling: nofo.is_rolling || false,
               expirationDate: nofo.expiration_date || null,
               grantType: (nofo.grant_type as NOFO["grantType"]) || null,
               agency: nofo.agency || null,

--- a/lib/user-interface/app/src/styles/dashboard.css
+++ b/lib/user-interface/app/src/styles/dashboard.css
@@ -1009,6 +1009,19 @@ body {
   font-weight: 400;
 }
 
+.expiry-date.rolling {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 12px;
+  border: 1px solid #0d6ecc40;
+  background-color: #e8f1fb;
+  color: #0d6ecc;
+  white-space: nowrap;
+}
+
 /* File upload styling */
 .file-upload-container {
   position: relative;

--- a/lib/user-interface/app/src/styles/landing-page-table.css
+++ b/lib/user-interface/app/src/styles/landing-page-table.css
@@ -177,6 +177,19 @@
   font-weight: 400;
 }
 
+.landing-expiry-date.rolling {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 12px;
+  border: 1px solid #0d6ecc40;
+  background-color: #e8f1fb;
+  color: #0d6ecc;
+  white-space: nowrap;
+}
+
 .landing-no-data {
   padding: 40px;
   text-align: center;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `is_rolling`/`isRolling` field that is persisted to S3/DynamoDB and surfaced in both admin and public UIs, which risks data shape/compatibility issues if any consumers or existing records don’t match the new schema. Also changes landing-page filter count calculations, which could affect user-facing totals but is otherwise localized UI logic.
> 
> **Overview**
> Adds **rolling-grant support** end-to-end: the `s3-nofo-status` Lambda accepts `isRolling`, writes `is_rolling` into `summary.json`, and updates/creates the DynamoDB metadata item with the same flag; the NOFO retrieval Lambda now returns `is_rolling` and the UI maps it into `NOFO.isRolling`.
> 
> Updates the admin dashboard and landing-page tables to display **“Rolling”** (with new pill styling) instead of a date when `isRolling` is true, and adds an admin edit control to toggle the rolling flag (disabling the deadline date input when enabled).
> 
> Improves landing-page filter dropdown counts so totals reflect the *other active filters* rather than always counting across the full dataset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 248f070be310edd04488f94e4b6b7267c0973da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->