### PR TITLE
Fix multi-tool chat reply and stuck draft generation

### DIFF
--- a/lib/chatbot-api/functions/draft-pipeline/assemble/index.mjs
+++ b/lib/chatbot-api/functions/draft-pipeline/assemble/index.mjs
@@ -5,8 +5,8 @@
  * the overall job status, and writes the final state to DDB.
  */
 
-import { DynamoDBClient, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
-import { marshall } from '@aws-sdk/util-dynamodb';
+import { DynamoDBClient, UpdateItemCommand, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 
 const dynamoClient = new DynamoDBClient({ region: 'us-east-1' });
 
@@ -41,8 +41,15 @@ export const handler = async (event) => {
 
   console.log(`Assemble: job ${jobId} — ${completedCount}/${totalSections} sections, status=${status}`);
 
-  // Write final state to DDB
-  await finalizeJob(jobId, sections, status, failedSections);
+  // Write final state to the jobs table and the draft row.
+  // The draft row update used to be done client-side from the polling loop in
+  // SectionsEditor.tsx; if the user closed the tab before the pipeline finished,
+  // the draft was stranded in status="generating_draft" forever. Doing it here
+  // makes the transition independent of whether anyone is watching.
+  await Promise.all([
+    finalizeJob(jobId, sections, status, failedSections),
+    finalizeDraft(userId, sessionId, sections, status),
+  ]);
 
   return {
     jobId,
@@ -95,5 +102,64 @@ async function finalizeJob(jobId, sections, status, failedSections) {
   } catch (error) {
     console.error(`Assemble: error finalizing job ${jobId}:`, error);
     throw error;
+  }
+}
+
+async function finalizeDraft(userId, sessionId, newSections, jobStatus) {
+  const tableName = process.env.DRAFT_TABLE_NAME;
+  if (!tableName) {
+    console.warn('Assemble: DRAFT_TABLE_NAME not set, skipping draft finalization');
+    return;
+  }
+  if (!userId || !sessionId) {
+    console.warn('Assemble: missing userId/sessionId, skipping draft finalization');
+    return;
+  }
+
+  const draftStatus = jobStatus === 'error' ? 'questionnaire' : 'editing_sections';
+
+  try {
+    let mergedSections = newSections;
+    const existing = await dynamoClient.send(new GetItemCommand({
+      TableName: tableName,
+      Key: { user_id: { S: userId }, session_id: { S: sessionId } },
+      ProjectionExpression: 'sections',
+    }));
+    if (existing.Item?.sections) {
+      const prior = unmarshall({ sections: existing.Item.sections }).sections || {};
+      mergedSections = { ...prior, ...newSections };
+    } else {
+      console.warn(`Assemble: no existing draft for ${userId}/${sessionId} — writing job results anyway`);
+    }
+
+    const updates = {
+      sections: mergedSections,
+      status: draftStatus,
+      last_modified: new Date().toISOString(),
+    };
+
+    const updateExpressions = [];
+    const expressionAttributeValues = {};
+    const expressionAttributeNames = {};
+    Object.keys(updates).forEach((key, index) => {
+      const valueKey = `:val${index}`;
+      const nameKey = `#name${index}`;
+      updateExpressions.push(`${nameKey} = ${valueKey}`);
+      expressionAttributeValues[valueKey] = updates[key];
+      expressionAttributeNames[nameKey] = key;
+    });
+
+    await dynamoClient.send(new UpdateItemCommand({
+      TableName: tableName,
+      Key: { user_id: { S: userId }, session_id: { S: sessionId } },
+      UpdateExpression: `SET ${updateExpressions.join(', ')}`,
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: marshall(expressionAttributeValues),
+    }));
+    console.log(`Assemble: finalized draft ${userId}/${sessionId} with status=${draftStatus}`);
+  } catch (error) {
+    // Don't fail the whole step — the jobs table still has the data and the
+    // frontend's polling fallback can still pick it up.
+    console.error(`Assemble: error finalizing draft ${userId}/${sessionId}:`, error);
   }
 }

--- a/lib/chatbot-api/functions/functions.ts
+++ b/lib/chatbot-api/functions/functions.ts
@@ -1227,6 +1227,7 @@ export class LambdaFunctionStack extends cdk.Stack {
         handler: "index.handler",
         environment: {
           DRAFT_GENERATION_JOBS_TABLE_NAME: props.draftGenerationJobsTable.tableName,
+          DRAFT_TABLE_NAME: props.draftTable.tableName,
         },
         timeout: cdk.Duration.seconds(30),
         memorySize: 128,
@@ -1237,7 +1238,10 @@ export class LambdaFunctionStack extends cdk.Stack {
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: ["dynamodb:UpdateItem", "dynamodb:GetItem"],
-        resources: [props.draftGenerationJobsTable.tableArn],
+        resources: [
+          props.draftGenerationJobsTable.tableArn,
+          props.draftTable.tableArn,
+        ],
       })
     );
 

--- a/lib/chatbot-api/functions/websocket-chat/index.mjs
+++ b/lib/chatbot-api/functions/websocket-chat/index.mjs
@@ -235,87 +235,105 @@ const getUserResponse = async (id, requestJSON, authenticatedUserId) => {
       const updatedSystemPrompt = `Active grant (documentIdentifier): ${documentIdentifier}${uploadedFilesList}\n\n${SYS_PROMPT}`;
       const stream = await claude.getStreamedResponse(updatedSystemPrompt, history);
       try {
+        // The model may emit multiple tool_use content blocks in one response
+        // (the system prompt explicitly invites several focused searches per
+        // question). Collect each block's input JSON separately so we don't
+        // concatenate them into a single string and choke JSON.parse later.
         let toolInput = "";
-        let assemblingInput = false;
-        let usingTool = false;
-        let toolId;
-        let skipChunk = true;
-        let message = {};
-        let toolUse = {};
-        
+        let currentTool = null;
+        const collectedTools = [];
+
+        const finalizeCurrentTool = () => {
+          if (currentTool) {
+            currentTool.inputRaw = toolInput;
+            collectedTools.push(currentTool);
+          }
+          currentTool = null;
+          toolInput = "";
+        };
+
         for await (const event of stream) {
           const chunk = JSON.parse(new TextDecoder().decode(event.chunk.bytes));
           const parsedChunk = await claude.parseChunk(chunk);
-          if (parsedChunk) {
-            if (parsedChunk.stop_reason) {
-              if (parsedChunk.stop_reason == "tool_use") {
-                assemblingInput = false;
-                usingTool = true;
-                skipChunk = true;
-              } else {
-                stopLoop = true;
-                break;
-              }
-            }
-            
-            if (parsedChunk.type) {
-              if (parsedChunk.type == "tool_use") {
-                assemblingInput = true;
-                toolId = parsedChunk.id;
-                message['role'] = 'assistant';
-                message['content'] = [];
-                toolUse['name'] = parsedChunk.name;
-                toolUse['type'] = 'tool_use';
-                toolUse['id'] = toolId;
-                toolUse['input'] = { query: "" };
-              }
-            }
-            
-            if (usingTool) {
-              let docString;
-              let query = JSON.parse(toolInput);
-              docString = await retrieveKBDocs(query.query, knowledgeBase, process.env.KB_ID, documentIdentifier, userId);
-              fullDocs.content = fullDocs.content.concat(docString.content);
-              fullDocs.uris = fullDocs.uris.concat(docString.uris);
-              
-              toolUse.input.query = query.query;
-              message.content.push(toolUse);
-              history.push(message);
-              
-              let toolResponse = {
-                role: "user",
-                content: [
-                  {
-                    type: "tool_result",
-                    tool_use_id: toolId,
-                    content: docString.content
+          if (!parsedChunk) continue;
+
+          // Terminal event for this streamed response.
+          if (parsedChunk.stop_reason) {
+            if (parsedChunk.stop_reason === "tool_use") {
+              finalizeCurrentTool();
+
+              if (collectedTools.length > 0) {
+                const assistantMessage = { role: "assistant", content: [] };
+                const toolResults = [];
+                for (const t of collectedTools) {
+                  let query;
+                  try {
+                    query = JSON.parse(t.inputRaw);
+                  } catch (e) {
+                    console.error(`Failed to parse tool input for ${t.id}: ${JSON.stringify(t.inputRaw)}`, e);
+                    query = { query: "" };
                   }
-                ]
-              };
-              
-              history.push(toolResponse);
-              
-              usingTool = false;
-              toolInput = "";
-            } else {
-              if (assemblingInput && !skipChunk) {
-                toolInput = toolInput.concat(parsedChunk);
-              } else if (!assemblingInput) {
-                let responseParams = {
-                  ConnectionId: id,
-                  Data: parsedChunk.toString()
-                };
-                modelResponse = modelResponse.concat(parsedChunk);
-                let command = new PostToConnectionCommand(responseParams);
-                        
-                try {
-                  await wsConnectionClient.send(command);
-                } catch (error) {
-                  console.error("Error sending chunk:", error);
+                  const docString = await retrieveKBDocs(
+                    query.query || "",
+                    knowledgeBase,
+                    process.env.KB_ID,
+                    documentIdentifier,
+                    userId
+                  );
+                  fullDocs.content = fullDocs.content.concat(docString.content);
+                  fullDocs.uris = fullDocs.uris.concat(docString.uris);
+
+                  assistantMessage.content.push({
+                    type: "tool_use",
+                    id: t.id,
+                    name: t.name,
+                    input: { query: query.query || "" },
+                  });
+                  toolResults.push({
+                    type: "tool_result",
+                    tool_use_id: t.id,
+                    content: docString.content,
+                  });
                 }
-              } else if (skipChunk) {
-                skipChunk = false;
+                history.push(assistantMessage);
+                history.push({ role: "user", content: toolResults });
               }
+              // Outer while loop will re-stream with updated history.
+              break;
+            }
+
+            stopLoop = true;
+            break;
+          }
+
+          // Start of a new tool_use content block.
+          if (parsedChunk.type === "tool_use") {
+            // If another tool block is already in flight (parallel / sequential
+            // tool_use blocks within a single response), finalize it first so
+            // its input buffer doesn't bleed into the new one.
+            finalizeCurrentTool();
+            currentTool = { id: parsedChunk.id, name: parsedChunk.name, inputRaw: "" };
+            continue;
+          }
+
+          // Inside a tool block: accumulate input_json_delta fragments.
+          if (currentTool) {
+            if (typeof parsedChunk === "string") {
+              toolInput = toolInput.concat(parsedChunk);
+            }
+            continue;
+          }
+
+          // Plain text delta — stream to the client.
+          if (typeof parsedChunk === "string") {
+            modelResponse = modelResponse.concat(parsedChunk);
+            try {
+              await wsConnectionClient.send(new PostToConnectionCommand({
+                ConnectionId: id,
+                Data: parsedChunk,
+              }));
+            } catch (error) {
+              console.error("Error sending chunk:", error);
             }
           }
         }


### PR DESCRIPTION
The chat handler concatenated input JSON from every tool_use block into one string and called JSON.parse on it, which silently crashed whenever the model emitted more than one tool_use block in a single streamed response (the system prompt explicitly invites multiple focused searches per question). The user saw no reply and the websocket eventually 410'd.

The draft-pipeline's assemble lambda only wrote back to the jobs table. Transitioning the Draft row from "generating_draft" to "editing_sections" was done client-side from the SectionsEditor polling loop, so if the user closed the tab before the pipeline finished the draft was stranded.

- websocket-chat/index.mjs: collect each tool_use content block separately during streaming, then on stop_reason emit one assistant message with every tool_use plus one user message with every matching tool_result.
- draft-pipeline/assemble/index.mjs: add finalizeDraft() that merges the generated sections into the existing draft row and sets status to editing_sections (or back to questionnaire on total failure).
- functions.ts: wire DRAFT_TABLE_NAME and Draft-table IAM into the assemble lambda.