### PR TITLE
Sync AI grant search work from main

### DIFF
--- a/lib/chatbot-api/functions/landing-page/ai-grant-search/index.mjs
+++ b/lib/chatbot-api/functions/landing-page/ai-grant-search/index.mjs
@@ -23,7 +23,7 @@ const FEATURE_ROLLOUT_MODES = new Set(['all', 'allowlisted', 'disabled']);
 
 const TITAN_MODEL_ID = 'amazon.titan-embed-text-v2:0';
 const EMBEDDING_DIM = 1024;
-const MAX_RESULTS = 20;
+const MAX_RESULTS = 50;
 const AOSS_TIMEOUT_MS = 10_000;
 const BM25_SATURATION_K = 5.0;
 const BM25_MIN_SHOULD_MATCH = '80%';
@@ -32,6 +32,7 @@ const SHORT_QUERY_WORD_LIMIT = 3;
 const CATEGORY_INDEX = 'CategoryIndex';
 const CATEGORY_BOOST_SCORE = 0.45;
 const NAME_MATCH_SCORE = 0.55;
+const RECENCY_TIE_EPSILON = 0.05;
 
 // Short queries (≤3 words) favour BM25 keywords; longer queries favour semantic meaning
 const SCORING = {
@@ -65,6 +66,71 @@ const STOP_WORDS = new Set([
   'grants', 'grant', 'funding', 'fund', 'funds', 'opportunities', 'opportunity',
   'programs', 'program', 'support', 'related',
   'federal', 'state', 'local', 'national', 'government',
+]);
+
+// Intent filter terms — stripped from the search text and used to filter results.
+const OPEN_TERMS = new Set(['open', 'active', 'current', 'available', 'accepting']);
+const CLOSED_TERMS = new Set(['closed', 'expired', 'past', 'archived', 'ended']);
+const ROLLING_TERMS = new Set(['rolling']);
+
+const CATEGORY_SYNONYMS = new Map([
+  ['resilience', ['Disaster Prevention and Relief', 'Environment', 'Infrastructure Investment and Jobs Act']],
+  ['climate',    ['Environment', 'Energy', 'Disaster Prevention and Relief']],
+  ['disaster',   ['Disaster Prevention and Relief']],
+  ['emergency',  ['Disaster Prevention and Relief']],
+  ['flood',      ['Disaster Prevention and Relief', 'Environment']],
+  ['flooding',   ['Disaster Prevention and Relief', 'Environment']],
+  ['wildfire',   ['Disaster Prevention and Relief', 'Natural Resources']],
+  ['hurricane',  ['Disaster Prevention and Relief']],
+  ['water',      ['Environment', 'Natural Resources']],
+  ['conservation', ['Natural Resources', 'Environment']],
+  ['wildlife',   ['Natural Resources']],
+  ['pollution',  ['Environment']],
+  ['recycling',  ['Environment']],
+  ['sustainability', ['Environment', 'Energy']],
+  ['renewable',  ['Energy']],
+  ['solar',      ['Energy']],
+  ['wind',       ['Energy']],
+  ['battery',    ['Energy', 'Energy Infrastructure and Critical Mineral and Materials (EICMM)']],
+  ['grid',       ['Energy', 'Energy Infrastructure and Critical Mineral and Materials (EICMM)']],
+  ['mineral',    ['Energy Infrastructure and Critical Mineral and Materials (EICMM)']],
+  ['transit',    ['Transportation', 'Infrastructure Investment and Jobs Act']],
+  ['road',       ['Transportation', 'Infrastructure Investment and Jobs Act']],
+  ['bridge',     ['Transportation', 'Infrastructure Investment and Jobs Act']],
+  ['highway',    ['Transportation', 'Infrastructure Investment and Jobs Act']],
+  ['broadband',  ['Infrastructure Investment and Jobs Act', 'Information and Statistics']],
+  ['infrastructure', ['Infrastructure Investment and Jobs Act']],
+  ['mental',     ['Health']],
+  ['medical',    ['Health']],
+  ['hospital',   ['Health']],
+  ['healthcare', ['Health', 'Affordable Care Act']],
+  ['substance',  ['Health']],
+  ['nutrition',  ['Food and Nutrition']],
+  ['food',       ['Food and Nutrition']],
+  ['school',     ['Education']],
+  ['schools',    ['Education']],
+  ['student',    ['Education']],
+  ['workforce',  ['Employment, Labor, and Training']],
+  ['job',        ['Employment, Labor, and Training']],
+  ['jobs',       ['Employment, Labor, and Training']],
+  ['training',   ['Employment, Labor, and Training']],
+  ['apprenticeship', ['Employment, Labor, and Training']],
+  ['housing',    ['Housing']],
+  ['homelessness', ['Housing', 'Income Security and Social Services']],
+  ['rural',      ['Regional Development', 'Agriculture']],
+  ['farm',       ['Agriculture']],
+  ['farming',    ['Agriculture']],
+  ['museum',     ['Arts', 'Humanities']],
+  ['research',   ['Science, Technology, and Other Research and Development']],
+  ['technology', ['Science, Technology, and Other Research and Development']],
+  ['stem',       ['Science, Technology, and Other Research and Development', 'Education']],
+  ['justice',    ['Law, Justice, and Legal Services']],
+  ['legal',      ['Law, Justice, and Legal Services']],
+  ['veteran',    ['Income Security and Social Services']],
+  ['veterans',   ['Income Security and Social Services']],
+  ['senior',     ['Income Security and Social Services', 'Health']],
+  ['seniors',    ['Income Security and Social Services', 'Health']],
+  ['consumer',   ['Consumer Protection']],
 ]);
 
 const bedrockClient = new BedrockRuntimeClient({ region: REGION });
@@ -157,16 +223,23 @@ export const handler = async (event) => {
     }
 
     const trimmedQuery = query.trim();
-    const wordCount = trimmedQuery.split(/\s+/).filter(Boolean).length;
-    console.log('Search query:', { query: trimmedQuery, wordCount });
+    const { statusFilter, rollingOnly, cleanedQuery } = parseIntent(trimmedQuery);
+    const searchQuery = cleanedQuery.length >= 3 ? cleanedQuery : trimmedQuery;
+    const wordCount = searchQuery.split(/\s+/).filter(Boolean).length;
+    console.log('Search query:', { query: trimmedQuery, searchQuery, statusFilter, rollingOnly, wordCount });
 
-    const embedding = await generateEmbedding(trimmedQuery);
+    const intentFilterActive = Boolean(statusFilter || rollingOnly);
+    const metadataPromise = getMetadataCache();
 
-    const matchedCategory = matchCategory(trimmedQuery);
-    const [hybridResults, categoryNames, nameMatches] = await Promise.all([
-      hybridSearch(trimmedQuery, embedding, MAX_RESULTS),
-      matchedCategory ? fetchGrantsByCategory(matchedCategory) : [],
-      fetchGrantsByName(trimmedQuery),
+    const embedding = await generateEmbedding(searchQuery);
+
+    const matchedCategories = matchCategory(searchQuery);
+    const [hybridResults, categoryFetches, nameMatches] = await Promise.all([
+      hybridSearch(searchQuery, embedding, MAX_RESULTS),
+      Promise.all(
+        matchedCategories.map(async (category) => ({ category, names: await fetchGrantsByCategory(category) }))
+      ),
+      fetchGrantsByName(searchQuery),
     ]);
 
     // Merge all sources, deduplicate, boost hybrid results that also matched by name
@@ -186,20 +259,38 @@ export const handler = async (event) => {
       all.push({ name, score: NAME_MATCH_SCORE, source: 'name', reason: 'Matched by grant name' });
     }
 
-    for (const name of categoryNames) {
-      if (seen.has(name)) continue;
-      seen.add(name);
-      all.push({ name, score: CATEGORY_BOOST_SCORE, source: 'category', reason: `In category: ${matchedCategory}` });
+    let totalCategoryHits = 0;
+    for (const { category, names } of categoryFetches) {
+      totalCategoryHits += names.length;
+      for (const name of names) {
+        if (seen.has(name)) continue;
+        seen.add(name);
+        all.push({ name, score: CATEGORY_BOOST_SCORE, source: 'category', reason: `In category: ${category}` });
+      }
     }
 
-    all.sort((a, b) => b.score - a.score);
-    const finalResults = all.slice(0, MAX_RESULTS);
+    const metaMap = await metadataPromise;
+    let finalPool = all;
+    let filteredOut = 0;
+    if (intentFilterActive) {
+      finalPool = all.filter((r) => matchesIntentFilter(metaMap.get(r.name), statusFilter, rollingOnly));
+      filteredOut = all.length - finalPool.length;
+    }
+    finalPool.sort((a, b) => {
+      const scoreDiff = b.score - a.score;
+      if (Math.abs(scoreDiff) >= RECENCY_TIE_EPSILON) return scoreDiff;
+      const aTs = expirationTimestamp(metaMap.get(a.name));
+      const bTs = expirationTimestamp(metaMap.get(b.name));
+      if (aTs !== bTs) return bTs - aTs;
+      return scoreDiff;
+    });
+    const finalResults = finalPool.slice(0, MAX_RESULTS);
 
-    if (nameMatches.length > 0) console.log(`Name matches: ${nameMatches.length} grants contain "${trimmedQuery}" in name`);
-    if (categoryNames.length > 0) console.log(`Category matches: ${categoryNames.length} grants in "${matchedCategory}"`);
+    if (nameMatches.length > 0) console.log(`Name matches: ${nameMatches.length} grants contain "${searchQuery}" in name`);
+    if (totalCategoryHits > 0) console.log(`Category matches: ${totalCategoryHits} grants across [${matchedCategories.join(', ')}]`);
 
     const searchTimeMs = Date.now() - startTime;
-    console.log('Search complete:', { resultCount: finalResults.length, searchTimeMs });
+    console.log('Search complete:', { resultCount: finalResults.length, filteredOut, statusFilter, rollingOnly, searchTimeMs });
 
     return respond(200, {
       results: finalResults,
@@ -292,25 +383,123 @@ function fuzzyMatchCategory(word, lookup) {
   return bestDist <= maxDist ? best : null;
 }
 
-/**
- * Match query to a category. Strips stop words, tries full phrase first,
- * then single-word fuzzy match (only when one meaningful word remains).
- * "transportation" → Transportation, "mental health" → no match (not = "Health")
- */
+
 function matchCategory(query) {
   const words = query.toLowerCase().split(/\s+/).filter((w) => !STOP_WORDS.has(w) && w.length > 1);
-  if (words.length === 0) return null;
+  if (words.length === 0) return [];
 
   const phrase = words.join(' ');
   const exactMatch = CATEGORY_LOOKUP.get(phrase);
-  if (exactMatch) return exactMatch;
+  if (exactMatch) return [exactMatch];
 
   if (words.length === 1) {
     const match = fuzzyMatchCategory(words[0], SINGLE_WORD_CATEGORIES);
-    if (match) return match;
+    if (match) return [match];
   }
 
-  return null;
+  const synonymHits = new Set();
+  for (const w of words) {
+    const cats = CATEGORY_SYNONYMS.get(w);
+    if (cats) for (const c of cats) synonymHits.add(c);
+  }
+  return [...synonymHits];
+}
+
+function parseIntent(query) {
+  const tokens = query.split(/\s+/).filter(Boolean);
+  let statusFilter = null;
+  let rollingOnly = false;
+  const kept = [];
+  for (const tok of tokens) {
+    const norm = tok.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (OPEN_TERMS.has(norm))       { statusFilter = 'open';   continue; }
+    if (CLOSED_TERMS.has(norm))     { statusFilter = 'closed'; continue; }
+    if (ROLLING_TERMS.has(norm))    { rollingOnly = true;      continue; }
+    kept.push(tok);
+  }
+  return { statusFilter, rollingOnly, cleanedQuery: kept.join(' ').trim() };
+}
+
+const METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
+let metadataCache = null;
+let metadataCacheFetchedAt = 0;
+let inflightMetadataFetch = null;
+
+async function getMetadataCache() {
+  const now = Date.now();
+  if (metadataCache && now - metadataCacheFetchedAt < METADATA_CACHE_TTL_MS) return metadataCache;
+  if (inflightMetadataFetch) return inflightMetadataFetch;
+  if (!METADATA_TABLE) return new Map();
+
+  inflightMetadataFetch = (async () => {
+    const map = new Map();
+    let lastKey;
+    try {
+      do {
+        const result = await dynamoClient.send(
+          new ScanCommand({
+            TableName: METADATA_TABLE,
+            ProjectionExpression: 'nofo_name, #s, expiration_date, is_rolling',
+            ExpressionAttributeNames: { '#s': 'status' },
+            ExclusiveStartKey: lastKey,
+          })
+        );
+        for (const item of result.Items || []) {
+          const m = unmarshall(item);
+          if (m.nofo_name) map.set(m.nofo_name, m);
+        }
+        lastKey = result.LastEvaluatedKey;
+      } while (lastKey);
+      metadataCache = map;
+      metadataCacheFetchedAt = Date.now();
+      console.log('Metadata cache populated:', { entries: map.size });
+      return map;
+    } catch (err) {
+      console.error('Metadata cache scan failed:', err.message);
+      // Serve stale cache rather than dropping the filter silently
+      return metadataCache || new Map();
+    } finally {
+      inflightMetadataFetch = null;
+    }
+  })();
+
+  return inflightMetadataFetch;
+}
+
+function isRolling(meta) {
+  const v = meta?.is_rolling;
+  return v === true || v === 'true';
+}
+
+function expirationTimestamp(meta) {
+  if (!meta) return 0;
+  if (meta.status === 'archived') return 0;
+  if (isRolling(meta)) return Number.POSITIVE_INFINITY;
+  if (!meta.expiration_date) return 0;
+  const t = Date.parse(meta.expiration_date);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function matchesIntentFilter(meta, statusFilter, rollingOnly) {
+  // Missing metadata → keep the result rather than silently dropping it.
+  if (!meta) return true;
+  if (rollingOnly && !isRolling(meta)) return false;
+  if (!statusFilter) return true;
+  const now = Date.now();
+  if (statusFilter === 'open') {
+    if (meta.status === 'archived') return false;
+    if (isRolling(meta)) return true;
+    if (!meta.expiration_date) return true;
+    const t = Date.parse(meta.expiration_date);
+    return Number.isNaN(t) ? true : t >= now;
+  }
+  if (statusFilter === 'closed') {
+    if (meta.status === 'archived') return true;
+    if (!meta.expiration_date) return false;
+    const t = Date.parse(meta.expiration_date);
+    return Number.isNaN(t) ? false : t < now;
+  }
+  return true;
 }
 
 async function fetchGrantsByCategory(category) {

--- a/lib/user-interface/app/src/hooks/use-ai-grant-search.ts
+++ b/lib/user-interface/app/src/hooks/use-ai-grant-search.ts
@@ -76,9 +76,12 @@ export function useAIGrantSearch(): UseAIGrantSearchReturn {
         cacheRef.current.delete(trimmed);
       }
 
-      // Abort any previous in-flight request
       abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
       cancelledRef.current = false;
+      const timeoutId = setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS);
+      const isLatest = () => abortControllerRef.current === controller && !cancelledRef.current;
 
       setIsSearching(true);
       setError(null);
@@ -86,35 +89,28 @@ export function useAIGrantSearch(): UseAIGrantSearchReturn {
 
       try {
         const session = await Auth.currentSession();
+        if (!isLatest()) return;
         const idToken = session.getIdToken().getJwtToken();
         const endpoint = appContext.httpEndpoint;
 
-        const controller = new AbortController();
-        abortControllerRef.current = controller;
-        const timeoutId = setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS);
+        const response = await fetch(`${endpoint}/ai-grant-search`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${idToken}`,
+          },
+          body: JSON.stringify({ query: query.trim() }),
+          signal: controller.signal,
+        });
 
-        let response: Response;
-        try {
-          response = await fetch(`${endpoint}/ai-grant-search`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${idToken}`,
-            },
-            body: JSON.stringify({ query: query.trim() }),
-            signal: controller.signal,
-          });
-        } finally {
-          clearTimeout(timeoutId);
-        }
-
-        if (cancelledRef.current) return;
-
+        if (!isLatest()) return;
         if (!response.ok) {
           throw new Error(`Search failed (${response.status})`);
         }
 
         const data: AISearchResponse = await response.json();
+        if (!isLatest()) return;
+
         const newResults = data.results || [];
         setResults(newResults);
         setSearchTimeMs(data.searchTimeMs);
@@ -131,7 +127,7 @@ export function useAIGrantSearch(): UseAIGrantSearchReturn {
           timestamp: Date.now(),
         });
       } catch (err) {
-        if (cancelledRef.current) return;
+        if (!isLatest()) return;
         let message: string;
         if (err instanceof DOMException && err.name === "AbortError") {
           message = "Search timed out. Try a more specific query or full sentence.";
@@ -143,9 +139,10 @@ export function useAIGrantSearch(): UseAIGrantSearchReturn {
         setError(message);
         setResults([]);
       } finally {
-        if (!cancelledRef.current) {
+        clearTimeout(timeoutId);
+        if (abortControllerRef.current === controller) {
           abortControllerRef.current = null;
-          setIsSearching(false);
+          if (!cancelledRef.current) setIsSearching(false);
         }
       }
     },

--- a/lib/user-interface/app/src/pages/landing-page/GrantsTable.tsx
+++ b/lib/user-interface/app/src/pages/landing-page/GrantsTable.tsx
@@ -84,9 +84,7 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
     return map;
   }, [searchResults]);
 
-  // Once results have arrived, trust them — don't keep showing the spinner if a
-  // pending flag drifts true (e.g. user kept typing while a search was in flight).
-  const awaitingAIResults = (isSearching || isSearchPending) && !searchResults;
+  const awaitingAIResults = isSearching || (isSearchPending && searchResults === null);
 
   const getFilteredNofos = () => {
     const searchLower = searchTerm.toLowerCase().trim();


### PR DESCRIPTION
Bring three AI-search files up to main's version so staging-ma is a true superset of main. Two commits on main never flowed back into staging-ma: 05fa148 (Enhance AI grant search functionality and user experience) and e94657d (Implement tiebreaker logic in AI grant search to prioritize recent deadlines and enhance metadata handling).

Files:
- lib/chatbot-api/functions/landing-page/ai-grant-search/index.mjs
- lib/user-interface/app/src/hooks/use-ai-grant-search.ts
- lib/user-interface/app/src/pages/landing-page/GrantsTable.tsx

Environment-specific files (index.html, App.tsx GA tracking IDs) are intentionally left at staging-ma's values.