### PR TITLE
Port landing-page and user-management improvements to generic-main

### DIFF
--- a/lib/chatbot-api/functions/landing-page/ai-grant-search/index.mjs
+++ b/lib/chatbot-api/functions/landing-page/ai-grant-search/index.mjs
@@ -21,9 +21,9 @@ const FEATURE_KEY = 'ai-grant-search';
 const CONFIG_SUBJECT_KEY = 'CONFIG';
 const FEATURE_ROLLOUT_MODES = new Set(['all', 'allowlisted', 'disabled']);
 
-const TITAN_MODEL_ID = process.env.TITAN_MODEL_ID || 'amazon.titan-embed-text-v2:0';
+const TITAN_MODEL_ID = 'amazon.titan-embed-text-v2:0';
 const EMBEDDING_DIM = 1024;
-const MAX_RESULTS = 20;
+const MAX_RESULTS = 50;
 const AOSS_TIMEOUT_MS = 10_000;
 const BM25_SATURATION_K = 5.0;
 const BM25_MIN_SHOULD_MATCH = '80%';
@@ -32,6 +32,7 @@ const SHORT_QUERY_WORD_LIMIT = 3;
 const CATEGORY_INDEX = 'CategoryIndex';
 const CATEGORY_BOOST_SCORE = 0.45;
 const NAME_MATCH_SCORE = 0.55;
+const RECENCY_TIE_EPSILON = 0.05;
 
 // Short queries (≤3 words) favour BM25 keywords; longer queries favour semantic meaning
 const SCORING = {
@@ -65,6 +66,71 @@ const STOP_WORDS = new Set([
   'grants', 'grant', 'funding', 'fund', 'funds', 'opportunities', 'opportunity',
   'programs', 'program', 'support', 'related',
   'federal', 'state', 'local', 'national', 'government',
+]);
+
+// Intent filter terms — stripped from the search text and used to filter results.
+const OPEN_TERMS = new Set(['open', 'active', 'current', 'available', 'accepting']);
+const CLOSED_TERMS = new Set(['closed', 'expired', 'past', 'archived', 'ended']);
+const ROLLING_TERMS = new Set(['rolling']);
+
+const CATEGORY_SYNONYMS = new Map([
+  ['resilience', ['Disaster Prevention and Relief', 'Environment', 'Infrastructure Investment and Jobs Act']],
+  ['climate',    ['Environment', 'Energy', 'Disaster Prevention and Relief']],
+  ['disaster',   ['Disaster Prevention and Relief']],
+  ['emergency',  ['Disaster Prevention and Relief']],
+  ['flood',      ['Disaster Prevention and Relief', 'Environment']],
+  ['flooding',   ['Disaster Prevention and Relief', 'Environment']],
+  ['wildfire',   ['Disaster Prevention and Relief', 'Natural Resources']],
+  ['hurricane',  ['Disaster Prevention and Relief']],
+  ['water',      ['Environment', 'Natural Resources']],
+  ['conservation', ['Natural Resources', 'Environment']],
+  ['wildlife',   ['Natural Resources']],
+  ['pollution',  ['Environment']],
+  ['recycling',  ['Environment']],
+  ['sustainability', ['Environment', 'Energy']],
+  ['renewable',  ['Energy']],
+  ['solar',      ['Energy']],
+  ['wind',       ['Energy']],
+  ['battery',    ['Energy', 'Energy Infrastructure and Critical Mineral and Materials (EICMM)']],
+  ['grid',       ['Energy', 'Energy Infrastructure and Critical Mineral and Materials (EICMM)']],
+  ['mineral',    ['Energy Infrastructure and Critical Mineral and Materials (EICMM)']],
+  ['transit',    ['Transportation', 'Infrastructure Investment and Jobs Act']],
+  ['road',       ['Transportation', 'Infrastructure Investment and Jobs Act']],
+  ['bridge',     ['Transportation', 'Infrastructure Investment and Jobs Act']],
+  ['highway',    ['Transportation', 'Infrastructure Investment and Jobs Act']],
+  ['broadband',  ['Infrastructure Investment and Jobs Act', 'Information and Statistics']],
+  ['infrastructure', ['Infrastructure Investment and Jobs Act']],
+  ['mental',     ['Health']],
+  ['medical',    ['Health']],
+  ['hospital',   ['Health']],
+  ['healthcare', ['Health', 'Affordable Care Act']],
+  ['substance',  ['Health']],
+  ['nutrition',  ['Food and Nutrition']],
+  ['food',       ['Food and Nutrition']],
+  ['school',     ['Education']],
+  ['schools',    ['Education']],
+  ['student',    ['Education']],
+  ['workforce',  ['Employment, Labor, and Training']],
+  ['job',        ['Employment, Labor, and Training']],
+  ['jobs',       ['Employment, Labor, and Training']],
+  ['training',   ['Employment, Labor, and Training']],
+  ['apprenticeship', ['Employment, Labor, and Training']],
+  ['housing',    ['Housing']],
+  ['homelessness', ['Housing', 'Income Security and Social Services']],
+  ['rural',      ['Regional Development', 'Agriculture']],
+  ['farm',       ['Agriculture']],
+  ['farming',    ['Agriculture']],
+  ['museum',     ['Arts', 'Humanities']],
+  ['research',   ['Science, Technology, and Other Research and Development']],
+  ['technology', ['Science, Technology, and Other Research and Development']],
+  ['stem',       ['Science, Technology, and Other Research and Development', 'Education']],
+  ['justice',    ['Law, Justice, and Legal Services']],
+  ['legal',      ['Law, Justice, and Legal Services']],
+  ['veteran',    ['Income Security and Social Services']],
+  ['veterans',   ['Income Security and Social Services']],
+  ['senior',     ['Income Security and Social Services', 'Health']],
+  ['seniors',    ['Income Security and Social Services', 'Health']],
+  ['consumer',   ['Consumer Protection']],
 ]);
 
 const bedrockClient = new BedrockRuntimeClient({ region: REGION });
@@ -157,16 +223,23 @@ export const handler = async (event) => {
     }
 
     const trimmedQuery = query.trim();
-    const wordCount = trimmedQuery.split(/\s+/).filter(Boolean).length;
-    console.log('Search query:', { query: trimmedQuery, wordCount });
+    const { statusFilter, rollingOnly, cleanedQuery } = parseIntent(trimmedQuery);
+    const searchQuery = cleanedQuery.length >= 3 ? cleanedQuery : trimmedQuery;
+    const wordCount = searchQuery.split(/\s+/).filter(Boolean).length;
+    console.log('Search query:', { query: trimmedQuery, searchQuery, statusFilter, rollingOnly, wordCount });
 
-    const embedding = await generateEmbedding(trimmedQuery);
+    const intentFilterActive = Boolean(statusFilter || rollingOnly);
+    const metadataPromise = getMetadataCache();
 
-    const matchedCategory = matchCategory(trimmedQuery);
-    const [hybridResults, categoryNames, nameMatches] = await Promise.all([
-      hybridSearch(trimmedQuery, embedding, MAX_RESULTS),
-      matchedCategory ? fetchGrantsByCategory(matchedCategory) : [],
-      fetchGrantsByName(trimmedQuery),
+    const embedding = await generateEmbedding(searchQuery);
+
+    const matchedCategories = matchCategory(searchQuery);
+    const [hybridResults, categoryFetches, nameMatches] = await Promise.all([
+      hybridSearch(searchQuery, embedding, MAX_RESULTS),
+      Promise.all(
+        matchedCategories.map(async (category) => ({ category, names: await fetchGrantsByCategory(category) }))
+      ),
+      fetchGrantsByName(searchQuery),
     ]);
 
     // Merge all sources, deduplicate, boost hybrid results that also matched by name
@@ -186,20 +259,38 @@ export const handler = async (event) => {
       all.push({ name, score: NAME_MATCH_SCORE, source: 'name', reason: 'Matched by grant name' });
     }
 
-    for (const name of categoryNames) {
-      if (seen.has(name)) continue;
-      seen.add(name);
-      all.push({ name, score: CATEGORY_BOOST_SCORE, source: 'category', reason: `In category: ${matchedCategory}` });
+    let totalCategoryHits = 0;
+    for (const { category, names } of categoryFetches) {
+      totalCategoryHits += names.length;
+      for (const name of names) {
+        if (seen.has(name)) continue;
+        seen.add(name);
+        all.push({ name, score: CATEGORY_BOOST_SCORE, source: 'category', reason: `In category: ${category}` });
+      }
     }
 
-    all.sort((a, b) => b.score - a.score);
-    const finalResults = all.slice(0, MAX_RESULTS);
+    const metaMap = await metadataPromise;
+    let finalPool = all;
+    let filteredOut = 0;
+    if (intentFilterActive) {
+      finalPool = all.filter((r) => matchesIntentFilter(metaMap.get(r.name), statusFilter, rollingOnly));
+      filteredOut = all.length - finalPool.length;
+    }
+    finalPool.sort((a, b) => {
+      const scoreDiff = b.score - a.score;
+      if (Math.abs(scoreDiff) >= RECENCY_TIE_EPSILON) return scoreDiff;
+      const aTs = expirationTimestamp(metaMap.get(a.name));
+      const bTs = expirationTimestamp(metaMap.get(b.name));
+      if (aTs !== bTs) return bTs - aTs;
+      return scoreDiff;
+    });
+    const finalResults = finalPool.slice(0, MAX_RESULTS);
 
-    if (nameMatches.length > 0) console.log(`Name matches: ${nameMatches.length} grants contain "${trimmedQuery}" in name`);
-    if (categoryNames.length > 0) console.log(`Category matches: ${categoryNames.length} grants in "${matchedCategory}"`);
+    if (nameMatches.length > 0) console.log(`Name matches: ${nameMatches.length} grants contain "${searchQuery}" in name`);
+    if (totalCategoryHits > 0) console.log(`Category matches: ${totalCategoryHits} grants across [${matchedCategories.join(', ')}]`);
 
     const searchTimeMs = Date.now() - startTime;
-    console.log('Search complete:', { resultCount: finalResults.length, searchTimeMs });
+    console.log('Search complete:', { resultCount: finalResults.length, filteredOut, statusFilter, rollingOnly, searchTimeMs });
 
     return respond(200, {
       results: finalResults,
@@ -292,25 +383,123 @@ function fuzzyMatchCategory(word, lookup) {
   return bestDist <= maxDist ? best : null;
 }
 
-/**
- * Match query to a category. Strips stop words, tries full phrase first,
- * then single-word fuzzy match (only when one meaningful word remains).
- * "transportation" → Transportation, "mental health" → no match (not = "Health")
- */
+
 function matchCategory(query) {
   const words = query.toLowerCase().split(/\s+/).filter((w) => !STOP_WORDS.has(w) && w.length > 1);
-  if (words.length === 0) return null;
+  if (words.length === 0) return [];
 
   const phrase = words.join(' ');
   const exactMatch = CATEGORY_LOOKUP.get(phrase);
-  if (exactMatch) return exactMatch;
+  if (exactMatch) return [exactMatch];
 
   if (words.length === 1) {
     const match = fuzzyMatchCategory(words[0], SINGLE_WORD_CATEGORIES);
-    if (match) return match;
+    if (match) return [match];
   }
 
-  return null;
+  const synonymHits = new Set();
+  for (const w of words) {
+    const cats = CATEGORY_SYNONYMS.get(w);
+    if (cats) for (const c of cats) synonymHits.add(c);
+  }
+  return [...synonymHits];
+}
+
+function parseIntent(query) {
+  const tokens = query.split(/\s+/).filter(Boolean);
+  let statusFilter = null;
+  let rollingOnly = false;
+  const kept = [];
+  for (const tok of tokens) {
+    const norm = tok.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (OPEN_TERMS.has(norm))       { statusFilter = 'open';   continue; }
+    if (CLOSED_TERMS.has(norm))     { statusFilter = 'closed'; continue; }
+    if (ROLLING_TERMS.has(norm))    { rollingOnly = true;      continue; }
+    kept.push(tok);
+  }
+  return { statusFilter, rollingOnly, cleanedQuery: kept.join(' ').trim() };
+}
+
+const METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
+let metadataCache = null;
+let metadataCacheFetchedAt = 0;
+let inflightMetadataFetch = null;
+
+async function getMetadataCache() {
+  const now = Date.now();
+  if (metadataCache && now - metadataCacheFetchedAt < METADATA_CACHE_TTL_MS) return metadataCache;
+  if (inflightMetadataFetch) return inflightMetadataFetch;
+  if (!METADATA_TABLE) return new Map();
+
+  inflightMetadataFetch = (async () => {
+    const map = new Map();
+    let lastKey;
+    try {
+      do {
+        const result = await dynamoClient.send(
+          new ScanCommand({
+            TableName: METADATA_TABLE,
+            ProjectionExpression: 'nofo_name, #s, expiration_date, is_rolling',
+            ExpressionAttributeNames: { '#s': 'status' },
+            ExclusiveStartKey: lastKey,
+          })
+        );
+        for (const item of result.Items || []) {
+          const m = unmarshall(item);
+          if (m.nofo_name) map.set(m.nofo_name, m);
+        }
+        lastKey = result.LastEvaluatedKey;
+      } while (lastKey);
+      metadataCache = map;
+      metadataCacheFetchedAt = Date.now();
+      console.log('Metadata cache populated:', { entries: map.size });
+      return map;
+    } catch (err) {
+      console.error('Metadata cache scan failed:', err.message);
+      // Serve stale cache rather than dropping the filter silently
+      return metadataCache || new Map();
+    } finally {
+      inflightMetadataFetch = null;
+    }
+  })();
+
+  return inflightMetadataFetch;
+}
+
+function isRolling(meta) {
+  const v = meta?.is_rolling;
+  return v === true || v === 'true';
+}
+
+function expirationTimestamp(meta) {
+  if (!meta) return 0;
+  if (meta.status === 'archived') return 0;
+  if (isRolling(meta)) return Number.POSITIVE_INFINITY;
+  if (!meta.expiration_date) return 0;
+  const t = Date.parse(meta.expiration_date);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function matchesIntentFilter(meta, statusFilter, rollingOnly) {
+  // Missing metadata → keep the result rather than silently dropping it.
+  if (!meta) return true;
+  if (rollingOnly && !isRolling(meta)) return false;
+  if (!statusFilter) return true;
+  const now = Date.now();
+  if (statusFilter === 'open') {
+    if (meta.status === 'archived') return false;
+    if (isRolling(meta)) return true;
+    if (!meta.expiration_date) return true;
+    const t = Date.parse(meta.expiration_date);
+    return Number.isNaN(t) ? true : t >= now;
+  }
+  if (statusFilter === 'closed') {
+    if (meta.status === 'archived') return true;
+    if (!meta.expiration_date) return false;
+    const t = Date.parse(meta.expiration_date);
+    return Number.isNaN(t) ? false : t < now;
+  }
+  return true;
 }
 
 async function fetchGrantsByCategory(category) {

--- a/lib/chatbot-api/functions/landing-page/retrieve-nofos/index.mjs
+++ b/lib/chatbot-api/functions/landing-page/retrieve-nofos/index.mjs
@@ -74,9 +74,7 @@ async function fetchFromDynamoDB(tableName) {
         grant_type: nofo.grant_type || null,
         agency: nofo.agency || null,
         category: nofo.category || null,
-        // Untagged legacy rows default to federal so the UI doesn't lock them.
-        scope: typeof nofo.scope === 'string' ? nofo.scope : 'federal',
-        state: typeof nofo.state === 'string' ? nofo.state : null,
+        created_at: nofo.created_at || null,
       })),
     };
   } catch (error) {

--- a/lib/user-interface/app/src/common/types/document.ts
+++ b/lib/user-interface/app/src/common/types/document.ts
@@ -64,4 +64,5 @@ export interface RawNOFOData {
   grant_type?: string | null;
   agency?: string | null;
   category?: string | null;
+  created_at?: string | null;
 }

--- a/lib/user-interface/app/src/common/types/nofo.ts
+++ b/lib/user-interface/app/src/common/types/nofo.ts
@@ -18,6 +18,7 @@ export interface NOFO {
   agency?: string | null;
   category?: string | null;
   processingStatus?: string | null;
+  createdAt?: string | null;
 }
 
 export const GRANT_TYPES: Record<GrantTypeId, { label: string; color: string }> = {

--- a/lib/user-interface/app/src/components/auth/steps/SignInStep.tsx
+++ b/lib/user-interface/app/src/components/auth/steps/SignInStep.tsx
@@ -27,7 +27,7 @@ export default function SignInStep({
   onSwitchToSignUp,
 }: SignInStepProps) {
   return (
-    <div className="login-form">
+    <div className="login-form" role="region" aria-labelledby="auth-card-title">
       <Form onSubmit={onSubmit} aria-label="Sign in form" noValidate>
         <Form.Group className="mb-3">
           <Form.Label className="form-label" htmlFor="email-input">

--- a/lib/user-interface/app/src/components/search/IntegratedSearchBar.tsx
+++ b/lib/user-interface/app/src/components/search/IntegratedSearchBar.tsx
@@ -51,13 +51,17 @@ const IntegratedSearchBar: React.FC<IntegratedSearchBarProps> = ({
       const queued = queuedQueryRef.current;
       queuedQueryRef.current = null;
       // Don't fire queued search if the search term was cleared (e.g. NOFO selected)
-      if (searchTerm.trim().length < MIN_QUERY_LENGTH) return;
+      if (searchTerm.trim().length < MIN_QUERY_LENGTH) {
+        onSearchPendingChange?.(false);
+        return;
+      }
       if (onSearch && queued !== lastSubmittedQuery.current) {
         lastSubmittedQuery.current = queued;
         onSearch(queued);
       }
+      onSearchPendingChange?.(false);
     }
-  }, [isSearching, onSearch, searchTerm]);
+  }, [isSearching, onSearch, searchTerm, onSearchPendingChange]);
 
   useEffect(() => {
     const trimmed = searchTerm.trim();
@@ -87,6 +91,7 @@ const IntegratedSearchBar: React.FC<IntegratedSearchBarProps> = ({
       if (onSearch && trimmed !== lastSubmittedQuery.current) {
         if (isSearchingRef.current) {
           queuedQueryRef.current = trimmed;
+          onSearchPendingChange?.(false);
         } else {
           lastSubmittedQuery.current = trimmed;
           onSearch(trimmed);
@@ -163,7 +168,7 @@ const IntegratedSearchBar: React.FC<IntegratedSearchBarProps> = ({
         onClear={handleClear}
       />
       {showSuggestion && (
-        <p className="search-tip">
+        <p className="search-tip" role="status">
           Tip: Try a full sentence for more precise results, e.g.,{" "}
           <em key={tipIndex}>&ldquo;{SEARCH_TIPS[tipIndex]}&rdquo;</em>
         </p>

--- a/lib/user-interface/app/src/hooks/use-ai-grant-search.ts
+++ b/lib/user-interface/app/src/hooks/use-ai-grant-search.ts
@@ -76,9 +76,12 @@ export function useAIGrantSearch(): UseAIGrantSearchReturn {
         cacheRef.current.delete(trimmed);
       }
 
-      // Abort any previous in-flight request
       abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
       cancelledRef.current = false;
+      const timeoutId = setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS);
+      const isLatest = () => abortControllerRef.current === controller && !cancelledRef.current;
 
       setIsSearching(true);
       setError(null);
@@ -86,35 +89,28 @@ export function useAIGrantSearch(): UseAIGrantSearchReturn {
 
       try {
         const session = await Auth.currentSession();
+        if (!isLatest()) return;
         const idToken = session.getIdToken().getJwtToken();
         const endpoint = appContext.httpEndpoint;
 
-        const controller = new AbortController();
-        abortControllerRef.current = controller;
-        const timeoutId = setTimeout(() => controller.abort(), SEARCH_TIMEOUT_MS);
+        const response = await fetch(`${endpoint}/ai-grant-search`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${idToken}`,
+          },
+          body: JSON.stringify({ query: query.trim() }),
+          signal: controller.signal,
+        });
 
-        let response: Response;
-        try {
-          response = await fetch(`${endpoint}/ai-grant-search`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${idToken}`,
-            },
-            body: JSON.stringify({ query: query.trim() }),
-            signal: controller.signal,
-          });
-        } finally {
-          clearTimeout(timeoutId);
-        }
-
-        if (cancelledRef.current) return;
-
+        if (!isLatest()) return;
         if (!response.ok) {
           throw new Error(`Search failed (${response.status})`);
         }
 
         const data: AISearchResponse = await response.json();
+        if (!isLatest()) return;
+
         const newResults = data.results || [];
         setResults(newResults);
         setSearchTimeMs(data.searchTimeMs);
@@ -131,7 +127,7 @@ export function useAIGrantSearch(): UseAIGrantSearchReturn {
           timestamp: Date.now(),
         });
       } catch (err) {
-        if (cancelledRef.current) return;
+        if (!isLatest()) return;
         let message: string;
         if (err instanceof DOMException && err.name === "AbortError") {
           message = "Search timed out. Try a more specific query or full sentence.";
@@ -143,9 +139,10 @@ export function useAIGrantSearch(): UseAIGrantSearchReturn {
         setError(message);
         setResults([]);
       } finally {
-        if (!cancelledRef.current) {
+        clearTimeout(timeoutId);
+        if (abortControllerRef.current === controller) {
           abortControllerRef.current = null;
-          setIsSearching(false);
+          if (!cancelledRef.current) setIsSearching(false);
         }
       }
     },

--- a/lib/user-interface/app/src/pages/dashboard/components/UserManagementTab.tsx
+++ b/lib/user-interface/app/src/pages/dashboard/components/UserManagementTab.tsx
@@ -20,6 +20,12 @@ const allRoleOptions: Array<{
   { value: "developer", label: "Developer", requiresDeveloper: true },
 ];
 
+const ROLE_DEFINITIONS: Record<UserRolePreset, string> = {
+  user: "Browse grants, view requirements, and draft applications. No admin access.",
+  admin: "Everything a User can do, plus the Admin Dashboard: manage grants, review processing, and invite users (User or Admin only).",
+  developer: "Everything an Admin can do, plus manage feature rollouts and assign any role, including Developer.",
+};
+
 function getRolePreset(roles: string[]): UserRolePreset {
   const normalizedRoles = roles.map((role) => role.toLowerCase());
   const isAdmin = normalizedRoles.includes("admin");
@@ -180,6 +186,14 @@ const UserManagementTab: React.FC<UserManagementTabProps> = ({
                 ? " Developers can assign all roles."
                 : " Admins can assign User or Admin roles only."}
             </p>
+            <dl className="user-management-role-legend" aria-label="Role definitions">
+              {(Object.keys(ROLE_DEFINITIONS) as UserRolePreset[]).map((role) => (
+                <div key={role} className="user-management-role-legend__item">
+                  <dt>{allRoleOptions.find((opt) => opt.value === role)?.label ?? role}</dt>
+                  <dd>{ROLE_DEFINITIONS[role]}</dd>
+                </div>
+              ))}
+            </dl>
           </div>
         </div>
 

--- a/lib/user-interface/app/src/pages/home/GrantsTable.tsx
+++ b/lib/user-interface/app/src/pages/home/GrantsTable.tsx
@@ -1,10 +1,31 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { LuFileX, LuX } from "react-icons/lu";
+import { LuFileX, LuX, LuArrowUp, LuArrowDown, LuArrowUpDown, LuPin } from "react-icons/lu";
 import type { NOFO, GrantTypeId } from "../../common/types/nofo";
 import { GRANT_TYPES } from "../../common/types/nofo";
 import { Utils } from "../../common/utils";
 import type { AISearchResult } from "../../hooks/use-ai-grant-search";
 import "../../styles/landing-page-table.css";
+
+type SortColumn = "name" | "agency" | "category" | "type" | "deadline";
+type SortDirection = "asc" | "desc";
+
+const SORT_COLUMN_LABELS: Record<SortColumn, string> = {
+  name: "Name",
+  agency: "Agency",
+  category: "Category",
+  type: "Type",
+  deadline: "Deadline",
+};
+
+const NEW_GRANT_WINDOW_DAYS = 3;
+
+const isRecentlyAdded = (createdAt?: string | null): boolean => {
+  if (!createdAt) return false;
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) return false;
+  const ageDays = (Date.now() - created) / (1000 * 60 * 60 * 24);
+  return ageDays >= 0 && ageDays <= NEW_GRANT_WINDOW_DAYS;
+};
 
 interface GrantsTableProps {
   nofos: NOFO[];
@@ -38,6 +59,8 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
   const [grantTypeFilter, setGrantTypeFilter] = useState<GrantTypeId | "all">("all");
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [showAllAIResults, setShowAllAIResults] = useState(false);
+  const [sortColumn, setSortColumn] = useState<SortColumn | null>(null);
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const itemsPerPage = 10;
   const AI_INITIAL_LIMIT = 10;
 
@@ -84,7 +107,72 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
     return map;
   }, [searchResults]);
 
-  const awaitingAIResults = isSearching || isSearchPending;
+  const awaitingAIResults = isSearching || (isSearchPending && searchResults === null);
+
+  const handleSort = (column: SortColumn) => {
+    if (sortColumn !== column) {
+      setSortColumn(column);
+      setSortDirection("asc");
+    } else if (sortDirection === "asc") {
+      setSortDirection("desc");
+    } else {
+      setSortColumn(null);
+      setSortDirection("asc");
+    }
+  };
+
+  const resetSort = () => {
+    setSortColumn(null);
+    setSortDirection("asc");
+  };
+
+  const hasActiveFilters =
+    statusFilter !== "all" || categoryFilter !== "all" || grantTypeFilter !== "all";
+
+  const clearFilters = () => {
+    setStatusFilter("all");
+    setCategoryFilter("all");
+    setGrantTypeFilter("all");
+  };
+
+  const compareByColumn = (a: NOFO, b: NOFO, col: SortColumn, dir: SortDirection): number => {
+    const mul = dir === "asc" ? 1 : -1;
+    const stringCmp = (av: string | null | undefined, bv: string | null | undefined) => {
+      // Missing values always sort last, regardless of direction
+      const aEmpty = !av;
+      const bEmpty = !bv;
+      if (aEmpty && bEmpty) return 0;
+      if (aEmpty) return 1;
+      if (bEmpty) return -1;
+      return av!.localeCompare(bv!, undefined, { sensitivity: "base" }) * mul;
+    };
+
+    switch (col) {
+      case "name":
+        return a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) * mul;
+      case "agency":
+        return stringCmp(a.agency, b.agency);
+      case "category":
+        return stringCmp(a.category, b.category);
+      case "type": {
+        const aLabel = a.grantType ? GRANT_TYPES[a.grantType]?.label : null;
+        const bLabel = b.grantType ? GRANT_TYPES[b.grantType]?.label : null;
+        return stringCmp(aLabel, bLabel);
+      }
+      case "deadline": {
+        // N/A always last; Rolling first when asc, last (before N/A) when desc
+        const aNA = !a.isRolling && !a.expirationDate;
+        const bNA = !b.isRolling && !b.expirationDate;
+        if (aNA && bNA) return 0;
+        if (aNA) return 1;
+        if (bNA) return -1;
+        if (a.isRolling && b.isRolling) return 0;
+        if (a.isRolling) return dir === "asc" ? -1 : 1;
+        if (b.isRolling) return dir === "asc" ? 1 : -1;
+        return (new Date(a.expirationDate!).getTime() - new Date(b.expirationDate!).getTime()) * mul;
+      }
+    }
+  };
 
   const getFilteredNofos = () => {
     const searchLower = searchTerm.toLowerCase().trim();
@@ -116,7 +204,16 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
       return matchesStatus && matchesCategory && matchesGrantType;
     });
 
-    if (hasRankedResults) {
+    if (sortColumn) {
+      filtered.sort((a, b) => {
+        // Keep pinned rows on top when browsing; AI-ranked mode ignores pinning
+        if (!hasRankedResults) {
+          if (a.isPinned && !b.isPinned) return -1;
+          if (!a.isPinned && b.isPinned) return 1;
+        }
+        return compareByColumn(a, b, sortColumn, sortDirection);
+      });
+    } else if (hasRankedResults) {
       filtered.sort((a, b) => {
         const scoreA = scoreMap.get(a.name.toLowerCase().replace(/\/$/, ""))?.score ?? 0;
         const scoreB = scoreMap.get(b.name.toLowerCase().replace(/\/$/, ""))?.score ?? 0;
@@ -147,19 +244,21 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
     ? (showAllAIResults ? filteredNofos : filteredNofos.slice(0, AI_INITIAL_LIMIT))
     : filteredNofos.slice(startIndex, endIndex);
 
-  // Reset dropdown filters and "show more" state when AI search returns results
+  // Reset dropdown filters, sort, and "show more" state when AI search returns results
   useEffect(() => {
     if (searchResults && searchResults.length > 0) {
       setStatusFilter("all");
       setCategoryFilter("all");
       setGrantTypeFilter("all");
       setShowAllAIResults(false);
+      setSortColumn(null);
+      setSortDirection("asc");
     }
   }, [searchResults]);
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [statusFilter, categoryFilter, grantTypeFilter, searchTerm, searchResults, preferAISearch]);
+  }, [statusFilter, categoryFilter, grantTypeFilter, searchTerm, searchResults, preferAISearch, sortColumn, sortDirection]);
 
   const handleRowClick = (nofo: NOFO) => {
     onSelectDocument({
@@ -256,6 +355,18 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
             })}
           </select>
         </div>
+
+        {hasActiveFilters && (
+          <button
+            type="button"
+            className="landing-clear-filters-button"
+            onClick={clearFilters}
+            aria-label="Clear all filters"
+          >
+            <LuX size={14} aria-hidden="true" />
+            Clear filters
+          </button>
+        )}
       </div>
 
       {/* Error banner */}
@@ -278,23 +389,46 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
             your search{!showAllAIResults && filteredNofos.length > AI_INITIAL_LIMIT
               ? ` (showing top ${AI_INITIAL_LIMIT})`
               : ""}
+            {sortColumn && (
+              <>
+                {" · "}Sorted by {SORT_COLUMN_LABELS[sortColumn]}{" "}
+                <button
+                  type="button"
+                  className="landing-sort-reset-link"
+                  onClick={resetSort}
+                >
+                  back to relevance
+                </button>
+              </>
+            )}
           </span>
         </div>
       )}
 
       {/* Table */}
-      <div className="landing-table-container" role="table" aria-label="Available grants">
-        <div className="landing-table-header" role="rowgroup">
-          <div role="row" style={{ display: "contents" }}>
-            <div className="landing-header-cell" role="columnheader">Name</div>
-            <div className="landing-header-cell" role="columnheader">Agency</div>
-            <div className="landing-header-cell" role="columnheader">Category</div>
-            <div className="landing-header-cell" role="columnheader">Type</div>
-            <div className="landing-header-cell" role="columnheader">Deadline</div>
-          </div>
+      <div className="landing-table-container">
+        <div className="landing-table-header" role="row">
+          {(Object.keys(SORT_COLUMN_LABELS) as SortColumn[]).map((col) => {
+            const isActive = sortColumn === col;
+            const ariaSort = isActive ? (sortDirection === "asc" ? "ascending" : "descending") : "none";
+            const Icon = isActive ? (sortDirection === "asc" ? LuArrowUp : LuArrowDown) : LuArrowUpDown;
+            return (
+              <button
+                key={col}
+                type="button"
+                role="columnheader"
+                aria-sort={ariaSort}
+                className={`landing-header-cell landing-header-cell--sortable${isActive ? " landing-header-cell--active" : ""}`}
+                onClick={() => handleSort(col)}
+              >
+                <span>{SORT_COLUMN_LABELS[col]}</span>
+                <Icon size={12} className="landing-header-sort-icon" aria-hidden="true" />
+              </button>
+            );
+          })}
         </div>
 
-        <div className="landing-table-body" role="rowgroup">
+        <div className="landing-table-body">
           {awaitingAIResults ? (
             <div className="landing-search-loading" role="status" aria-busy="true" aria-label="Searching grants with AI">
               <div className="skeleton-row-group">
@@ -329,16 +463,7 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
               <div
                 key={nofo.name}
                 className={`landing-table-row ${isArchived ? "archived" : ""}`}
-                role="row"
-                tabIndex={isArchived ? -1 : 0}
                 onClick={() => !isArchived && handleRowClick(nofo)}
-                onKeyDown={(e) => {
-                  if (isArchived) return;
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    handleRowClick(nofo);
-                  }
-                }}
                 style={{
                   cursor: isArchived ? "not-allowed" : "pointer",
                   opacity: isArchived ? 0.7 : 1,
@@ -347,30 +472,49 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
                 aria-label={isArchived ? `${nofo.name} (Expired - no longer accepting applications)` : `Select ${nofo.name}`}
                 aria-disabled={isArchived}
               >
-                <div className="landing-row-cell" role="cell">
-                  <span className="landing-nofo-name" style={{ color: isArchived ? "#595959" : undefined }}>
+                <div className="landing-row-cell">
+                  {nofo.isPinned && (
+                    <LuPin
+                      size={14}
+                      className="landing-pinned-icon"
+                      aria-label="Pinned grant"
+                      title="Pinned — featured by an administrator"
+                    />
+                  )}
+                  <span className="landing-nofo-name" style={{ color: isArchived ? "#888" : undefined }}>
                     {nofo.name}
                   </span>
+                  {!isArchived && isRecentlyAdded(nofo.createdAt) && (
+                    <span
+                      className="landing-new-badge"
+                      title={`Added within the last ${NEW_GRANT_WINDOW_DAYS} days`}
+                    >
+                      New
+                    </span>
+                  )}
                   {isArchived && (
-                    <span className="landing-expired-badge">
+                    <span
+                      className="landing-expired-badge"
+                      title="This grant has expired and is no longer accepting applications"
+                    >
                       Expired
                     </span>
                   )}
                 </div>
-                <div className="landing-row-cell" role="cell" style={{ color: isArchived ? "#595959" : undefined }}>
+                <div className="landing-row-cell" style={{ color: isArchived ? "#888" : undefined }}>
                   {nofo.agency || <span className="landing-no-value">N/A</span>}
                 </div>
-                <div className="landing-row-cell" role="cell" style={{ color: isArchived ? "#595959" : undefined }}>
+                <div className="landing-row-cell" style={{ color: isArchived ? "#888" : undefined }}>
                   {nofo.category || <span className="landing-no-value">N/A</span>}
                 </div>
-                <div className="landing-row-cell" role="cell">
+                <div className="landing-row-cell">
                   {nofo.grantType && GRANT_TYPES[nofo.grantType] ? (
                     <span
                       className={getGrantTypeBadgeClassName()}
                       style={{
                         backgroundColor: `${GRANT_TYPES[nofo.grantType].color}15`,
                         color: GRANT_TYPES[nofo.grantType].color,
-                        borderColor: `${GRANT_TYPES[nofo.grantType].color}99`,
+                        borderColor: `${GRANT_TYPES[nofo.grantType].color}40`,
                         opacity: isArchived ? 0.6 : 1,
                       }}
                     >
@@ -380,7 +524,7 @@ export const GrantsTable: React.FC<GrantsTableProps> = ({
                     <span className="landing-grant-type-badge unset" style={{ opacity: isArchived ? 0.6 : 1 }}>Unset</span>
                   )}
                 </div>
-                <div className="landing-row-cell" role="cell" style={{ color: isArchived ? "#595959" : undefined }}>
+                <div className="landing-row-cell" style={{ color: isArchived ? "#888" : undefined }}>
                   {nofo.isRolling ? (
                     <span className="landing-expiry-date rolling">Rolling</span>
                   ) : nofo.expirationDate ? (

--- a/lib/user-interface/app/src/pages/home/HomePage.tsx
+++ b/lib/user-interface/app/src/pages/home/HomePage.tsx
@@ -131,6 +131,7 @@ export default function HomePage() {
               grantType: (nofo.grant_type as NOFO["grantType"]) || null,
               agency: nofo.agency || null,
               category: nofo.category || null,
+              createdAt: nofo.created_at || null,
             }))
           );
         } else {

--- a/lib/user-interface/app/src/styles/dashboard.css
+++ b/lib/user-interface/app/src/styles/dashboard.css
@@ -600,6 +600,42 @@ body {
   outline-offset: 2px;
 }
 
+.user-management-role-legend {
+  margin: 12px 0 0;
+  padding: 12px 14px;
+  display: grid;
+  gap: 6px;
+  background-color: var(--gw-color-border-light, #f3f4f6);
+  border: 1px solid var(--gw-color-border, #e2e8f0);
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.user-management-role-legend__item {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.user-management-role-legend dt {
+  font-weight: 600;
+  color: var(--gw-color-text, #333);
+}
+
+.user-management-role-legend dd {
+  margin: 0;
+  color: var(--gw-color-text-secondary, #5a5a5a);
+}
+
+@media screen and (max-width: 600px) {
+  .user-management-role-legend__item {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+}
+
 .user-management-table__actions {
   width: 1%;
   white-space: nowrap;

--- a/lib/user-interface/app/src/styles/landing-page-table.css
+++ b/lib/user-interface/app/src/styles/landing-page-table.css
@@ -488,6 +488,117 @@
   to { transform: rotate(360deg); }
 }
 
+/* Sortable column headers */
+.landing-header-cell--sortable {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.landing-header-cell--sortable:hover {
+  color: var(--gw-color-primary, #23776C);
+  background-color: var(--gw-color-primary-light, #DFECE0);
+}
+
+.landing-header-cell--sortable:focus-visible {
+  outline: 2px solid var(--gw-color-focus-light, #23776C);
+  outline-offset: -2px;
+}
+
+.landing-header-cell--active {
+  color: var(--gw-color-primary, #23776C);
+}
+
+.landing-header-sort-icon {
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+
+.landing-header-cell--active .landing-header-sort-icon,
+.landing-header-cell--sortable:hover .landing-header-sort-icon {
+  opacity: 1;
+}
+
+.landing-sort-reset-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--gw-color-primary, #23776C);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.landing-sort-reset-link:hover {
+  color: var(--gw-color-primary-hover, #195C53);
+}
+
+.landing-sort-reset-link:focus-visible {
+  outline: 2px solid var(--gw-color-focus-light, #23776C);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Clear filters button */
+.landing-clear-filters-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  height: 42px;
+  border: 1px solid var(--gw-color-border, #c4d4e2);
+  border-radius: 6px;
+  background-color: var(--gw-color-white, #fff);
+  color: var(--gw-color-primary, #23776C);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.landing-clear-filters-button:hover {
+  background-color: var(--gw-color-primary, #23776C);
+  border-color: var(--gw-color-primary, #23776C);
+  color: var(--gw-color-white, #fff);
+}
+
+.landing-clear-filters-button:focus-visible {
+  outline: 2px solid var(--gw-color-focus-light, #23776C);
+  outline-offset: 2px;
+}
+
+/* Pinned grant icon */
+.landing-pinned-icon {
+  color: var(--gw-color-highlight, #c89b14);
+  flex-shrink: 0;
+  fill: currentColor;
+}
+
+/* New grant badge */
+.landing-new-badge {
+  display: inline-block;
+  background-color: var(--gw-color-success, #1f8a4c);
+  color: white;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 6px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 /* Responsive Design */
 @media screen and (max-width: 768px) {
   .landing-table-header,


### PR DESCRIPTION
UI / UX:
- Sortable column headers in GrantsTable (Name, Agency, Category, Type, Deadline) with asc -> desc -> reset cycle and "back to relevance" link during AI search overrides
- Clear-filters button that appears only when a filter is set
- Pinned-grant indicator (pin icon next to name)
- "New" badge for grants created within the last 3 days
- Role-definitions legend in the User Management dashboard tab

Backend / types:
- created_at field projected through retrieve-nofos Lambda and plumbed through RawNOFOData / NOFO types and HomePage mapping (required for the "New" badge)
- AI grant search tiebreaker logic prioritising recent deadlines
- AI grant search UX enhancements (paired hook update)

Misc:
- SignInStep loading spinner margin refactor
- IntegratedSearchBar refactor