### PR TITLE
Fix KB retrieval filter: use andAll operator and flat metadata keys

### DIFF
--- a/lib/chatbot-api/functions/websocket-chat/index.mjs
+++ b/lib/chatbot-api/functions/websocket-chat/index.mjs
@@ -71,17 +71,17 @@ async function retrieveKBDocs(query, knowledgeBase, knowledgeBaseID, documentIde
   const userDocFolderPath = userId ? `${userId}/${nofoName}/` : null;
 
   const nofoFilter = {
-    and: [
-      { equals: { key: "metadataAttributes.documentType", value: "NOFO" } },
-      { equals: { key: "metadataAttributes.documentIdentifier", value: normalizedDocumentIdentifier } }
+    andAll: [
+      { equals: { key: "documentType", value: "NOFO" } },
+      { equals: { key: "documentIdentifier", value: normalizedDocumentIdentifier } }
     ]
   };
 
   const userDocFilter = userId ? {
-    and: [
-      { equals: { key: "metadataAttributes.documentType", value: "userDocument" } },
-      { equals: { key: "metadataAttributes.userId", value: userId } },
-      { equals: { key: "metadataAttributes.nofoName", value: nofoName } }
+    andAll: [
+      { equals: { key: "documentType", value: "userDocument" } },
+      { equals: { key: "userId", value: userId } },
+      { equals: { key: "nofoName", value: nofoName } }
     ]
   } : null;
 


### PR DESCRIPTION
The Bedrock RetrievalFilter was built with the legacy `and` operator and `metadataAttributes.`-prefixed keys, which the current SDK fails to serialize (se_RetrievalFilter TypeError) before the request is sent. Since it surfaces as a client-side TypeError rather than a ValidationException, it bypasses the no-filter fallback and hard-fails retrieval.